### PR TITLE
feat: enable verbose for nuisance parameters

### DIFF
--- a/src/surrogate_index/__about__.py
+++ b/src/surrogate_index/__about__.py
@@ -2,4 +2,4 @@
 # SPDX-FileCopyrightText: 2025-present Kideok Kwon <kideokk16@gmail.com>
 # SPDX-License-Identifier: MIT
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"

--- a/src/surrogate_index/_logging.py
+++ b/src/surrogate_index/_logging.py
@@ -1,0 +1,19 @@
+import logging
+
+
+def enable_verbose_logging(level: int = logging.INFO) -> None:
+    """
+    Attach a StreamHandler to the `surrogate_index` logger
+    if one doesn't already exist. Used for verbose=True mode.
+    """
+    pkg_logger = logging.getLogger("surrogate_index")
+
+    if pkg_logger.handlers:
+        pkg_logger.setLevel(level)
+        return
+
+    handler = logging.StreamHandler()
+    handler.setFormatter(logging.Formatter("%(levelname)s:%(name)s:%(message)s"))
+    pkg_logger.addHandler(handler)
+    pkg_logger.setLevel(level)
+    pkg_logger.propagate = False  # don't send to root logger (avoid double prints)

--- a/src/surrogate_index/eif.py
+++ b/src/surrogate_index/eif.py
@@ -30,6 +30,8 @@ from .learners import (
     fit_nuisance_function_secondary,
 )
 from .preprocess import combine_dfs
+from ._logging import enable_verbose_logging
+
 
 # ---------------------------------------------------------------------
 # Config: logging
@@ -95,7 +97,7 @@ def efficient_influence_function(
 
     # --- turn package logging on if user asked for it ---
     if verbose:
-        logging.getLogger("surrogate_index").setLevel(logging.INFO)
+        enable_verbose_logging()
 
     # ------------------------------------------------------------------
     # Combine experimental & observational data


### PR DESCRIPTION
### Improve verbose logging behavior

Calling `efficient_influence_function(..., verbose=True)` now automatically enables logging to the console. Users no longer need to configure `logging` themselves to see progress logs during nuisance estimation.

The package remains silent by default unless `verbose=True` is explicitly set.
